### PR TITLE
fix: use node-modules linker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+# Yarn
+.yarn/
+yarn.lock
+.pnp.*

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ This Vue 3 app generates templates for sysvinit services.
 7. ???
 8. Profit!
 
+## Development
+
+Install dependencies and run the dev server with Yarn:
+
+```bash
+yarn install
+yarn dev
+
+# build the app
+yarn build
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@vue/eslint-config-prettier": "^10",
     "@vue/eslint-config-typescript": "^14",
     "@vue/tsconfig": "^0.7.0",
+    "@vue/typescript-plugin": "^3.0.1",
     "eslint": "^9",
     "eslint-plugin-vue": "^10",
     "npm-run-all2": "^8.0.0",
@@ -35,6 +36,7 @@
     "typescript": "~5.8.0",
     "vite": "^6",
     "vite-plugin-vue-devtools": "^7.0.18",
+    "vue-eslint-parser": "^10.2.0",
     "vue-tsc": "^3.0.0"
   }
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,5 +18,8 @@
         "./src/*"
       ]
     }
+  },
+  "vueCompilerOptions": {
+    "plugins": ["@vue/typescript-plugin"]
   }
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -10,5 +10,8 @@
   ],
   "exclude": [
     "node_modules"
-  ]
+  ],
+  "compilerOptions": {
+    "lib": ["es2023"]
+  }
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -11,6 +11,7 @@
     "composite": true,
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "lib": ["es2023"],
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "types": [


### PR DESCRIPTION
## Summary
- rely on node-modules linker instead of PnP
- include @vue/typescript-plugin for `vue-tsc`
- configure plugin via `tsconfig.app.json`
- keep `.yarnrc.yml` under version control

## Testing
- `yarn lint`
- `yarn type-lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68743f6d96dc832fa405258147265115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore rules to exclude Yarn-related files and directories from version control.
  * Added configuration to use the classic node_modules structure with Yarn.
  * Specified ES2023 as the target library for TypeScript compilation in relevant configuration files.
  * Added new development dependencies for improved Vue and TypeScript support.

* **Documentation**
  * Added a "Development" section to the README with setup and build instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->