### PR TITLE
fix: resolve tsconfig parsing issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+
+# Yarn
+.yarn/
+yarn.lock
+.pnp.*

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/README.md
+++ b/README.md
@@ -13,6 +13,22 @@ This Vue 3 app generates templates for sysvinit services.
 7. ???
 8. Profit!
 
+## Development
+
+Install dependencies and run the dev server with Yarn:
+
+```bash
+yarn install
+yarn dev
+
+# check code before committing
+yarn lint
+yarn type-lint
+
+# build the app
+yarn build
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build-only": "vite build",
     "type-check": "vue-tsc --build --force",
     "lint": "eslint . --fix",
-    "type-lint": "ts-standard",
-    "type-fix": "ts-standard --fix",
+    "type-lint": "vue-tsc --noEmit -p tsconfig.lint.json",
+    "type-fix": "ts-standard --fix --project tsconfig.lint.json",
     "format": "prettier --write src/ index.html .github/ .vscode/"
   },
   "dependencies": {
@@ -27,6 +27,7 @@
     "@vue/eslint-config-prettier": "^10",
     "@vue/eslint-config-typescript": "^14",
     "@vue/tsconfig": "^0.7.0",
+    "@vue/typescript-plugin": "^3.0.1",
     "eslint": "^9",
     "eslint-plugin-vue": "^10",
     "npm-run-all2": "^8.0.0",
@@ -35,6 +36,7 @@
     "typescript": "~5.8.0",
     "vite": "^6",
     "vite-plugin-vue-devtools": "^7.0.18",
+    "vue-eslint-parser": "^10.2.0",
     "vue-tsc": "^3.0.0"
   }
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -12,11 +12,16 @@
   "compilerOptions": {
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "strict": true,
+    "strictNullChecks": true,
     "baseUrl": ".",
     "paths": {
       "@/*": [
         "./src/*"
       ]
     }
+  },
+  "vueCompilerOptions": {
+    "plugins": ["@vue/typescript-plugin"]
   }
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,5 +1,4 @@
 {
-  "extends": "./tsconfig.node.json",
   "include": [
     "src/**/*.ts",
     "src/**/*.tsx",
@@ -10,5 +9,16 @@
   ],
   "exclude": [
     "node_modules"
-  ]
+  ],
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["es2023"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  }
 }

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.app.json",
+  "include": [
+    "env.d.ts",
+    "src/**/*",
+    "src/**/*.vue",
+    "eslint.config.mjs",
+    "vite.config.ts"
+  ],
+  "compilerOptions": {
+    "strict": true,
+    "strictNullChecks": true
+  }
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,5 +1,4 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
   "include": [
     "vite.config.*",
     "vitest.config.*",
@@ -8,11 +7,17 @@
     "playwright.config.*"
   ],
   "compilerOptions": {
+    "target": "ES2022",
+    "strict": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
     "composite": true,
     "noEmit": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "lib": ["es2023"],
     "module": "ESNext",
-    "moduleResolution": "Bundler",
     "types": [
       "node"
     ]


### PR DESCRIPTION
## Summary
- add strict options to TypeScript configs
- provide dedicated tsconfig for linting
- run `vue-tsc` for type linting
- document linting in README

## Testing
- `yarn lint`
- `yarn type-lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68743f6d96dc832fa405258147265115